### PR TITLE
Simplify frontend Dockerfile and update workflow permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,9 @@ on:
         type: choice
         options:
         - production
-        - staging
+
+permissions:
+  contents: read
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+  packages: write
+  security-events: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME_BACKEND: ${{ github.repository }}/backend
@@ -110,31 +115,6 @@ jobs:
       env:
         NEXT_PUBLIC_API_URL: http://localhost:3000/api
         NEXT_PUBLIC_APP_ENV: production
-  
-  # ==========================================
-  # Security Scanning
-  # ==========================================
-  security-scan:
-    name: Security Scan
-    runs-on: ubuntu-latest
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
-      with:
-        scan-type: 'fs'
-        scan-ref: '.'
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-    
-    - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v3
-      if: always()
-      with:
-        sarif_file: 'trivy-results.sarif'
   
   # ==========================================
   # Docker Image Build

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ develop, main ]
 
+permissions:
+  contents: read
+
 jobs:
   # ==========================================
   # Code Quality Checks

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,18 +3,11 @@ FROM node:18-alpine AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Install dependencies based on the preferred package manager
-COPY package.json bun.lock* package-lock.json* yarn.lock* pnpm-lock.yaml* ./
-RUN \
-  if [ -f bun.lock ]; then \
-    corepack enable && \
-    corepack prepare bun@stable --activate && \
-    bun install --frozen-lockfile; \
-  elif [ -f yarn.lock ]; then yarn --frozen-lockfile; \
-  elif [ -f package-lock.json ]; then npm ci; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
+# Copy package files
+COPY package.json package-lock.json* ./
+
+# Install dependencies with npm (more stable in Docker)
+RUN npm ci --omit=dev
 
 # Build stage
 FROM node:18-alpine AS builder
@@ -31,16 +24,7 @@ ENV NEXT_PUBLIC_APP_ENV=$NEXT_PUBLIC_APP_ENV
 ENV NEXT_TELEMETRY_DISABLED=1
 
 # Build the application
-RUN \
-  if [ -f bun.lock ]; then \
-    corepack enable && \
-    corepack prepare bun@stable --activate && \
-    bun run build; \
-  elif [ -f yarn.lock ]; then yarn run build; \
-  elif [ -f package-lock.json ]; then npm run build; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
+RUN npm run build
 
 # Production stage
 FROM node:18-alpine AS runner


### PR DESCRIPTION
This pull request makes several updates to CI/CD workflows and the frontend Dockerfile, focusing on improving security, simplifying dependency management, and standardizing build processes. The most important changes include adding explicit permissions to GitHub Actions workflows, removing the security scanning job from CI, and simplifying the frontend Dockerfile to use only npm for dependency installation and builds.

**Workflow Permissions and Security:**

* Added explicit `permissions` blocks to `.github/workflows/ci.yml`, `.github/workflows/cd.yml`, and `.github/workflows/dev.yml` to restrict GitHub Actions access, enhancing security and compliance. (`[[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR9-R13)`, `[[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L15-R17)`, `[[3]](diffhunk://#diff-914da273e1d936250929f1160bdd8be46aa865099502b04b471fe734f6b644ddR9-R11)`)
* Removed the `security-scan` job (Trivy vulnerability scanning and SARIF upload) from `.github/workflows/ci.yml`, streamlining the CI workflow. (`[.github/workflows/ci.ymlL114-L138](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL114-L138)`)

**Frontend Dockerfile Simplification:**

* Changed dependency installation in `frontend/Dockerfile` to use only npm (`npm ci --omit=dev`), removing support for Bun, Yarn, and PNPM, which improves stability in Docker builds. (`[frontend/DockerfileL6-R10](diffhunk://#diff-ea60ef29f6f537c1c83468c00b60de28f86e06edfe4a3d91274723c6f298fdb8L6-R10)`)
* Standardized the build command to always use `npm run build` in `frontend/Dockerfile`, eliminating conditional logic for different package managers. (`[frontend/DockerfileL34-R27](diffhunk://#diff-ea60ef29f6f537c1c83468c00b60de28f86e06edfe4a3d91274723c6f298fdb8L34-R27)`)