### PR TITLE
Add HTTPS support with SSL configuration

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -52,9 +52,28 @@ http {
         server frontend:3000;
     }
 
+    # HTTP server - redirect to HTTPS
     server {
         listen 80;
-        server_name localhost;
+        server_name sch-kpru.blurger.dev;
+        
+        # Redirect all HTTP traffic to HTTPS
+        return 301 https://$server_name$request_uri;
+    }
+
+    # HTTPS server
+    server {
+        listen 443 ssl http2;
+        server_name sch-kpru.blurger.dev;
+
+        # SSL configuration
+        ssl_certificate /etc/nginx/ssl/fullchain.pem;
+        ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305;
+        ssl_prefer_server_ciphers off;
+        ssl_session_cache shared:SSL:1m;
+        ssl_session_timeout 5m;
 
         # Security headers
         add_header X-Frame-Options "SAMEORIGIN" always;
@@ -133,29 +152,4 @@ http {
             deny all;
         }
     }
-
-    # HTTPS server (optional - uncomment if you have SSL certificates)
-    # server {
-    #     listen 443 ssl http2;
-    #     server_name your-domain.com;
-    #
-    #     ssl_certificate /etc/nginx/ssl/cert.pem;
-    #     ssl_certificate_key /etc/nginx/ssl/key.pem;
-    #
-    #     # SSL configuration
-    #     ssl_protocols TLSv1.2 TLSv1.3;
-    #     ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384;
-    #     ssl_prefer_server_ciphers off;
-    #
-    #     # Include the same configuration as HTTP server
-    #     location /api/ {
-    #         proxy_pass http://backend_api;
-    #         # ... same configuration as above
-    #     }
-    #
-    #     location / {
-    #         proxy_pass http://frontend_app;
-    #         # ... same configuration as above
-    #     }
-    # }
 }


### PR DESCRIPTION
This pull request updates the Nginx configuration to enable secure HTTPS support for the domain `sch-kpru.blurger.dev`. It adds a new HTTP server block to redirect all traffic to HTTPS and configures a dedicated HTTPS server block with SSL settings and security headers. The previous commented-out example for SSL support has been removed, making the configuration production-ready for this domain.

**HTTPS and SSL configuration:**

* Added a new HTTPS server block for `sch-kpru.blurger.dev` with SSL certificate paths, protocols (TLSv1.2, TLSv1.3), and secure cipher suites in `nginx/nginx.conf`.
* Removed the old commented-out example HTTPS server block, cleaning up the configuration for production use.

**HTTP to HTTPS redirection:**

* Added an HTTP server block to redirect all requests on port 80 to HTTPS for `sch-kpru.blurger.dev`, ensuring secure connections.

**Security improvements:**

* Included security headers (`X-Frame-Options`) in the HTTPS server block to enhance protection against clickjacking.